### PR TITLE
html로 export할 때 image를 base64로 인코딩해서 넣도록 처리함

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 
-val versionString = "0.1.1"
+val versionString = "0.1.2-SNAPSHOT"
 
 lazy val root = (project in file("."))
   .settings(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -38,7 +38,7 @@ object Dependencies {
     "com.h2database" % "h2" % "1.4.198"
   )
 
-  private val jasperReportVersion = "6.8.0"
+  private val jasperReportVersion = "6.9.0"
 
   val jasperreports: Seq[ModuleID] = Seq(
     // "net.sf.jasperreports" % "jasperreports-chart-themes", // this extension requires spring framework

--- a/src/main/scala/com/thing2x/rptsvr/engine/Report.scala
+++ b/src/main/scala/com/thing2x/rptsvr/engine/Report.scala
@@ -41,13 +41,13 @@ class Report(engine: ReportEngine, val reportUnitUri: String)(implicit ec: Execu
     fill(parameters).map ( exporter.exportReport )
   }
 
-  def exportReportToFile(parameters: Map[String, Any], format: ExportFormat.Value, destFilename: String): Future[File] = {
-    val exporter = ReportExporter(jsContext, format)
+  def exportReportToFile(parameters: Map[String, Any], format: ExportFormat.Value, destFilename: String, option:Option[String]): Future[File] = {
+    val exporter = ReportExporter(jsContext, format, option)
     fill(parameters).map( exporter.exportReportToFile(_, destFilename))
   }
 
-  def exportReportToFileSync(parameters: Map[String, Any], format: ExportFormat.Value, destFilename: String)(implicit timeout: FiniteDuration): File = {
-    val future = exportReportToFile(parameters, format, destFilename)
+  def exportReportToFileSync(parameters: Map[String, Any], format: ExportFormat.Value, destFilename: String, option:Option[String] = None)(implicit timeout: FiniteDuration): File = {
+    val future = exportReportToFile(parameters, format, destFilename, option)
     Await.result(future, timeout)
   }
 

--- a/src/main/scala/com/thing2x/rptsvr/engine/ReportEngine.scala
+++ b/src/main/scala/com/thing2x/rptsvr/engine/ReportEngine.scala
@@ -26,6 +26,7 @@ import akka.util.ByteString
 import com.thing2x.rptsvr.{DataSourceResource, JdbcDataSourceResource, ReportUnitResource, Repository}
 import com.thing2x.smqd.Smqd
 import com.thing2x.smqd.plugin.Service
+import com.thing2x.smqd.util.ConfigUtil._
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.StrictLogging
 import net.sf.jasperreports.engine._
@@ -151,7 +152,7 @@ class ReportEngine(name: String, smqd: Smqd, config: Config) extends Service(nam
         // get resource files as Map[name, InputStream]
         val resources: Future[Map[String, Any]] = Future.sequence(
           ru.resources map { case (resourceName, resource) =>
-            logger.trace(s"load report resource: $resourceName ${resource.resourceType} ${resource.fileType}")
+            logger.debug(s"load report resource: $resourceName - $resource ")
             if (useResourceCache) {
               val f = resourceCache.fromFuture(resource.uri, resource.updateDate.map(_.getTime)){ loadResource(resource.uri) }
               f.map{ rsc =>

--- a/src/main/scala/com/thing2x/rptsvr/engine/ReportExporter.scala
+++ b/src/main/scala/com/thing2x/rptsvr/engine/ReportExporter.scala
@@ -23,10 +23,10 @@ import com.thing2x.rptsvr.export._
 import net.sf.jasperreports.engine.{JasperPrint, JasperReportsContext}
 
 object ReportExporter {
-  def apply(jsContext: JasperReportsContext, format: ExportFormat.Value): ReportExporter = {
+  def apply(jsContext: JasperReportsContext, format: ExportFormat.Value, option:Option[String] = None): ReportExporter = {
     format match {
       case ExportFormat.pdf =>     new PdfExporter(jsContext)
-      case ExportFormat.html =>    new HtmlExporter(jsContext)
+      case ExportFormat.html =>    new HtmlExporter(jsContext, option)
       case ExportFormat.docx =>    new DocxExporter(jsContext)
       case ExportFormat.xls =>     new XlsExporter(jsContext)
       case ExportFormat.pptx =>    new PptxExporter(jsContext)

--- a/src/main/scala/com/thing2x/rptsvr/export/HtmlExporter.scala
+++ b/src/main/scala/com/thing2x/rptsvr/export/HtmlExporter.scala
@@ -17,8 +17,8 @@ package com.thing2x.rptsvr.export
 
 import java.io.File
 import java.io.ByteArrayOutputStream
-import java.io.FileOutputStream
 import java.util.Base64
+import java.io.PrintWriter
 
 import akka.util.ByteString
 import com.thing2x.rptsvr.engine.ReportExporter
@@ -28,11 +28,24 @@ import net.sf.jasperreports.export.SimpleExporterInput
 import net.sf.jasperreports.engine.export.HtmlResourceHandler
 import net.sf.jasperreports.export.SimpleHtmlExporterOutput
 import net.sf.jasperreports.export.SimpleHtmlReportConfiguration
+import net.sf.jasperreports.web.util.WebHtmlResourceHandler
 
 import scala.collection.mutable
+import scala.util.matching.Regex
 
-class HtmlExporter(jsContext: JasperReportsContext) extends ReportExporter with StrictLogging {
+/**
+  *
+  * @param jsContext JasperContext
+  * @param option
+  *        "base64" : embed image data by base64 encoding
+  *        "web:http://server/{0}" : convert the image source to the external link. {0} is replaced by the resource name
+  *           if the 'isLazy' option is turned on, the image source is replaced by RegEx
+  *             ex) url('repo:a.png') -> url('http://server/a.png')
+  */
+class HtmlExporter(jsContext: JasperReportsContext, option:Option[String]) extends ReportExporter with StrictLogging {
   private val images = mutable.Map.empty[String,String]
+  private val imageUrl = new Regex( """url\('(repo:|\.\/)([^']+)'\)""", "ignore", "file")
+  private val imageSrc = new Regex( """<img\s+src="(repo:|\.\/)([^"]+)"""", "ignore", "file")
 
   override def exportReport(jasperPrint: JasperPrint): ByteString = {
     val baos = new ByteArrayOutputStream()
@@ -46,30 +59,50 @@ class HtmlExporter(jsContext: JasperReportsContext) extends ReportExporter with 
   override def exportReportToFile(jasperPrint: JasperPrint, destpath: String): File = {
     val exporter = new underlying.HtmlExporter(jsContext)
     exporter.setExporterInput(new SimpleExporterInput(jasperPrint))
-    exporter.setExporterOutput(new SimpleHtmlExporterOutput(destpath))
 
-    val reportExportConfiguration = new SimpleHtmlReportConfiguration
+    logger.info(s"html export option: $option, path=$destpath")
 
-    exporter.setConfiguration(reportExportConfiguration)
+    option match {
+      case None =>
+        exporter.setExporterOutput(new SimpleHtmlExporterOutput(destpath))
+        exporter.exportReport()
 
-    val outputStream = new ByteArrayOutputStream()
-    val simpleHtmlExporterOutput = new SimpleHtmlExporterOutput(outputStream)
+      case Some(opt) =>
 
-    simpleHtmlExporterOutput.setImageHandler(new HtmlResourceHandler() {
-      override def handleResource(id: String, data: Array[Byte]): Unit = {
-        images.put(id, "data:image/jpg;base64," + Base64.getEncoder.encodeToString(data))
-      }
+        val reportExportConfiguration = new SimpleHtmlReportConfiguration
+        exporter.setConfiguration(reportExportConfiguration)
 
-      override def getResourcePath(id: String): String = images.getOrElse(id, "")
-    })
-    exporter.setExporterOutput(simpleHtmlExporterOutput)
-    exporter.exportReport()
+        val outputStream = new ByteArrayOutputStream()
+        val simpleHtmlExporterOutput = new SimpleHtmlExporterOutput(outputStream)
 
-    val file = new File(destpath)
-    val fos = new FileOutputStream( file)
-    outputStream.writeTo(fos)
-    fos.close()
+        if ( opt == "base64") {
+          simpleHtmlExporterOutput.setImageHandler(new HtmlResourceHandler() {
+            override def handleResource(id: String, data: Array[Byte]): Unit = {
+              logger.info(s"Image : $id ${jasperPrint.getProperty("image." + id)}")
+              images.put(id, "data:image/jpg;base64," + Base64.getEncoder.encodeToString(data))
+            }
 
-    file
+            override def getResourcePath(id: String): String = images.getOrElse(id, "")
+          })
+        }
+        else if ( opt.substring(0, 4) == "web:") {
+          simpleHtmlExporterOutput.setImageHandler(new WebHtmlResourceHandler( opt.substring(4)))
+        }
+
+        exporter.setExporterOutput(simpleHtmlExporterOutput)
+        exporter.exportReport()
+
+        val pattern = opt.substring(4)
+        val output1 = imageUrl.replaceAllIn( outputStream.toString(),
+          m => s"""url('${pattern.replaceAllLiterally("{0}", m group "file")}')""")
+        val output2 = imageSrc.replaceAllIn( output1,
+          m => s"""<img src="${pattern.replaceAllLiterally("{0}", m group "file")}" """)
+
+        val fos = new PrintWriter(destpath)
+        fos.write(output2)
+        fos.close()
+    }
+
+    new File(destpath)
   }
 }


### PR DESCRIPTION
export 할 때 기존 방법대로 처리하는 것과, base64로 embedding 하는 옵션을 두는 것도 좋겠습니다.